### PR TITLE
Remove visit notes from patient portal visit history display

### DIFF
--- a/patient-portal.php
+++ b/patient-portal.php
@@ -246,7 +246,7 @@ jQuery(function($) {
         <h3>Visit History</h3>
 
         <?php
-        $stmt = mysqli_prepare($link, "SELECT id, date, note, height, weight FROM notes WHERE p_id = ? ORDER BY date DESC");
+        $stmt = mysqli_prepare($link, "SELECT id, date, height, weight FROM notes WHERE p_id = ? ORDER BY date DESC");
         mysqli_stmt_bind_param($stmt, "i", $patient_id);
         mysqli_stmt_execute($stmt);
         $visits_result = mysqli_stmt_get_result($stmt);
@@ -266,7 +266,6 @@ jQuery(function($) {
                 <th>Height (cm)</th>
                 <th>Weight (kg)</th>
                 <th>BMI</th>
-                <th>Notes</th>
                 <th>Prescriptions</th>
                 <th>Invoices</th>
             </tr>
@@ -291,7 +290,6 @@ jQuery(function($) {
                     }
                     ?>
                     </td>
-                    <td><?php echo htmlspecialchars($row['note'] ?? ''); ?></td>
                     <td>
                     <?php
                     // Fetch prescriptions for this visit


### PR DESCRIPTION
## Summary
This PR removes the visit notes column from the patient portal's visit history table. The notes field is no longer queried from the database or displayed in the UI.

## Changes Made
- **Database Query**: Removed `note` field from the SELECT statement in the visit history query to reduce unnecessary data retrieval
- **Table Header**: Removed the "Notes" column header from the visit history table
- **Table Data**: Removed the table cell that displayed the visit notes content

## Implementation Details
The changes simplify the visit history display by focusing on essential clinical metrics (date, height, weight, BMI) and related actions (prescriptions, invoices) while removing the notes column. This reduces the query payload and declutters the patient portal interface.

The modification maintains all other visit tracking functionality including prescription and invoice management.

https://claude.ai/code/session_01HCXAfioV6ihU8pFQK7G4sL