### PR TITLE
Fix favicon not showing on drmahima.com

### DIFF
--- a/header.php
+++ b/header.php
@@ -27,7 +27,7 @@ if(isset($_GET['logout']))
 
 ?>
 <!DOCTYPE html>
-<link rel="shortcut icon" href="http://www.drmahima.com/favicon.ico" />
+<link rel="shortcut icon" href="/favicon.ico" />
 <head>
 <meta charset="utf8" />
 

--- a/patient-header.php
+++ b/patient-header.php
@@ -54,7 +54,7 @@ if ($currentFile == "patient-portal.php") {
 <!DOCTYPE html>
 <head>
 <meta charset="utf8" />
-<link rel="shortcut icon" href="http://www.drmahima.com/favicon.ico" />
+<link rel="shortcut icon" href="/favicon.ico" />
 <title><?php echo $pageTitle; ?></title>
 
 <link rel="stylesheet" type="text/css" media="screen" href="css/screen.css" />


### PR DESCRIPTION
## Summary\n- Favicon was not showing because the URL was hardcoded as `http://www.drmahima.com/favicon.ico` — browsers on HTTPS sites block HTTP resources (mixed content)\n- Fixed in both `header.php` and `patient-header.php` by replacing with a relative path `/favicon.ico`\n\n## Files changed\n- `header.php`\n- `patient-header.php`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCXAfioV6ihU8pFQK7G4sL)_