### PR TITLE
Support split payment modes in a single invoice

### DIFF
--- a/create-invoice.php
+++ b/create-invoice.php
@@ -2,6 +2,7 @@
 require('connect.php');
 include('header_db_link.php');
 include('header.php');
+require_once('invoice-payment-modes.php');
 
 session_name('tzLogin');
 session_start();
@@ -15,7 +16,15 @@ function addInvoice($link, $invoiceInfo) {
   if($discount == '')
     $discount = '0';
   $date = date('Y-m-d', strtotime($invoiceInfo['date']));
-  $mode = $invoiceInfo["mode"];
+  // Mode of payment. When the invoice is split across multiple modes
+  // (e.g. part cash, part UPI) build the encoded mode string from the
+  // per-mode amounts; otherwise keep the single selected mode as before.
+  if(isset($invoiceInfo['split_payment']) && is_array($invoiceInfo['split_amount'])) {
+    $builtMode = invoiceBuildModeString($invoiceInfo['split_amount']);
+    $mode = ($builtMode === '') ? $invoiceInfo["mode"] : $builtMode;
+  } else {
+    $mode = $invoiceInfo["mode"];
+  }
   $visit_id = $invoiceInfo['visit_id'];
   $length = sizeof($invoiceInfo['description']);
   for($i = 0; $i < $length; $i++) {
@@ -81,6 +90,7 @@ function addInvoice($link, $invoiceInfo) {
     $invoice_id = $doctor_header.$year."/00001";
   }
 
+  $mode = mysqli_real_escape_string($link, $mode);
   $query = "INSERT into invoice(p_id, date, mode, descriptions, amounts, invoice_id, doctor, discount) VALUES ('{$p_id}', '{$date}', '{$mode}', '{$descriptionConcat}', '{$amountConcat}', '{$invoice_id}', '{$doctor}', '{$discount}');";
   $retval = mysqli_query($link, $query);
   if($retval) {
@@ -137,6 +147,9 @@ function updateAmountTotal() {
   $("#totalBeforeDiscount").val(sum);
   sum = sum - $("#discount").val();
   $("#totalAmount").val(sum);
+  if(typeof updateSplitTotal === 'function') {
+    updateSplitTotal();
+  }
 }
 
 function setDescriptionAndAmountValues(val, id) {
@@ -154,10 +167,60 @@ $(document).on("change", "#discount", function() {
   updateAmountTotal();
 });
 
+function toggleSplitPayment() {
+  var on = document.getElementById('split_payment').checked;
+  document.getElementById('splitPaymentBox').style.display = on ? 'block' : 'none';
+  // When splitting, the single mode dropdown is ignored on the server; keep it
+  // enabled so it still posts a value (used as a fallback only).
+  document.getElementById('mode').style.opacity = on ? '0.5' : '1';
+  updateSplitTotal();
+}
+
+function getSplitTotal() {
+  var sum = 0;
+  $(".split-amounts").each(function(){
+    sum += +$(this).val();
+  });
+  return sum;
+}
+
+function updateSplitTotal() {
+  var splitSum = getSplitTotal();
+  document.getElementById('splitTotal').innerHTML = splitSum;
+  var finalAmount = +document.getElementById('totalAmount').value;
+  var mismatch = document.getElementById('split_payment').checked && splitSum != finalAmount;
+  document.getElementById('splitMismatch').style.display = mismatch ? 'inline' : 'none';
+}
+
+function confirmInvoice() {
+  var finalAmount = document.getElementById('totalAmount').value;
+  if(document.getElementById('split_payment').checked) {
+    var splitSum = getSplitTotal();
+    if(splitSum == 0) {
+      alert('Split is enabled but no amounts were entered. Please enter the amount received per mode.');
+      return false;
+    }
+    var msg = 'Create invoice with total amount: ' + finalAmount + ' split as ';
+    var parts = [];
+    $(".split-amounts").each(function(){
+      var val = +$(this).val();
+      if(val > 0) {
+        parts.push(this.name.replace('split_amount[','').replace(']','') + ': ' + val);
+      }
+    });
+    msg += parts.join(', ');
+    if(splitSum != finalAmount) {
+      msg += '\n\nWARNING: split total (' + splitSum + ') does not match the final amount (' + finalAmount + ').';
+    }
+    return confirm(msg + '?');
+  }
+  var modeSelect = document.getElementById('mode');
+  return confirm('Create invoice with total amount: ' + finalAmount + ' and mode of payment: ' + modeSelect.options[modeSelect.selectedIndex].text + '?');
+}
 
 </script>
 <h4>Create Invoice for <?php echo $patientName; ?></h4>
-<form onsubmit="return confirm('Create invoice with total amount: ' + document.getElementById('totalAmount').value + ' and mode of payment: ' + document.getElementById('mode').options[document.getElementById('mode').selectedIndex].text + '?');" action="" method="post" enctype="multipart/form-data" style="width:auto" >
+<form onsubmit="return confirmInvoice();" action="" method="post" enctype="multipart/form-data" style="width:auto" >
 <input type="hidden" name="p_id" value=<?php echo "'".$_GET['id']."'"; ?> />
   <input type="hidden" name="visit_id" value=<?php echo "'".$_GET['visit_id']."'"; ?> />
   <p>
@@ -179,7 +242,27 @@ $(document).on("change", "#discount", function() {
       <option value='PAYTM'>PayTM</option>
       <option value='UPI'>UPI</option>
     </select>
+    &nbsp;&nbsp;
+    <label class="grey" for="split_payment">
+      <input type="checkbox" name="split_payment" id="split_payment" value="1" onchange="toggleSplitPayment()"/>
+      Split across modes
+    </label>
   </p>
+  <div id="splitPaymentBox" style="display:none; margin: 0 0 10px 0; padding: 8px 12px; border: 1px solid #ccc; width: 320px;">
+    <p style="margin-top:0;">Enter amount received per mode (blank = not used):</p>
+    <?php
+      $splitModes = array('CASH' => 'Cash', 'CARD' => 'Card', 'PAYTM' => 'PayTM', 'UPI' => 'UPI');
+      foreach($splitModes as $value => $display) {
+        echo "<p style='margin:4px 0;'>";
+        echo "<label style='display:inline-block; width:70px;'>{$display}</label>";
+        echo "<input type='text' name='split_amount[{$value}]' class='split-amounts' onkeyup='updateSplitTotal()' onchange='updateSplitTotal()' style='font-size:15px; width:120px;'/>";
+        echo "</p>";
+      }
+    ?>
+    <p style="margin:4px 0;">Split total: <strong id="splitTotal">0</strong>
+      <span id="splitMismatch" style="color:#c0392b; display:none;">&nbsp;(does not match final amount)</span>
+    </p>
+  </div>
   <p>
     <label>Description and amount </label>
     <br>

--- a/invoice-payment-modes.php
+++ b/invoice-payment-modes.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Helpers for invoices that may be settled using more than one payment mode
+ * in a single invoice (e.g. part cash, part UPI).
+ *
+ * To avoid a schema change on the per-doctor databases, the split is encoded
+ * inside the existing single `invoice.mode` column:
+ *
+ *   - Single mode (legacy / default):  "CASH"
+ *   - Split across modes:              "CASH:300+UPI:200"
+ *
+ * A value is treated as a split when it contains a ':'. Everything else is
+ * treated as a plain single-mode value exactly as before, so existing rows
+ * keep working untouched.
+ */
+
+if (!function_exists('invoiceModeIsSplit')) {
+
+  function invoiceModeIsSplit($mode) {
+    return strpos((string)$mode, ':') !== false;
+  }
+
+  /**
+   * Formats a numeric amount without trailing ".00" noise (amounts are
+   * whole rupees in practice, but decimals are preserved if present).
+   */
+  function invoiceFormatAmount($amount) {
+    $amount = floatval($amount);
+    if ($amount == intval($amount)) {
+      return (string) intval($amount);
+    }
+    return rtrim(rtrim(number_format($amount, 2, '.', ''), '0'), '.');
+  }
+
+  /**
+   * Returns an associative array of mode => amount for an invoice.
+   *
+   * For a legacy single-mode invoice the whole $grandTotal is attributed to
+   * that mode. For a split invoice the per-mode amounts are read from the
+   * stored string and $grandTotal is ignored.
+   */
+  function invoiceParsePaymentModes($mode, $grandTotal) {
+    $mode = trim((string)$mode);
+    if ($mode === '') {
+      return array();
+    }
+    if (!invoiceModeIsSplit($mode)) {
+      return array($mode => floatval($grandTotal));
+    }
+    $result = array();
+    foreach (explode('+', $mode) as $part) {
+      if (strpos($part, ':') === false) {
+        continue;
+      }
+      list($m, $amt) = explode(':', $part, 2);
+      $m = trim($m);
+      if ($m === '') {
+        continue;
+      }
+      if (!isset($result[$m])) {
+        $result[$m] = 0;
+      }
+      $result[$m] += floatval($amt);
+    }
+    return $result;
+  }
+
+  /**
+   * Human-readable representation of the payment mode(s) for display on the
+   * invoice PDF and in listings, e.g. "CASH" or "CASH: 300, UPI: 200".
+   */
+  function invoiceFormatPaymentModes($mode) {
+    $mode = trim((string)$mode);
+    if (!invoiceModeIsSplit($mode)) {
+      return $mode;
+    }
+    $pieces = array();
+    foreach (invoiceParsePaymentModes($mode, 0) as $m => $amt) {
+      $pieces[] = $m . ': ' . invoiceFormatAmount($amt);
+    }
+    return implode(', ', $pieces);
+  }
+
+  /**
+   * Builds the value to store in the `mode` column from an array of
+   * mode => amount. Zero/empty amounts are dropped. When exactly one mode
+   * has a value, the legacy single-mode string is returned for backwards
+   * compatibility.
+   */
+  function invoiceBuildModeString($modeAmounts) {
+    $clean = array();
+    foreach ($modeAmounts as $m => $amt) {
+      $m = trim($m);
+      $amt = floatval($amt);
+      if ($m === '' || $amt <= 0) {
+        continue;
+      }
+      if (!isset($clean[$m])) {
+        $clean[$m] = 0;
+      }
+      $clean[$m] += $amt;
+    }
+    if (count($clean) === 0) {
+      return '';
+    }
+    if (count($clean) === 1) {
+      return (string) array_keys($clean)[0];
+    }
+    $pieces = array();
+    foreach ($clean as $m => $amt) {
+      $pieces[] = $m . ':' . invoiceFormatAmount($amt);
+    }
+    return implode('+', $pieces);
+  }
+}
+?>

--- a/invoice-results.php
+++ b/invoice-results.php
@@ -2,6 +2,7 @@
 if($_SESSION['type']!=='doctor') {
   exit();
 }
+require_once('invoice-payment-modes.php');
 //What needs to be done on this page:
 // List out all schedules for a particular date, in a form.
 // The dates *only* can be edited. Give a link for the patient also.
@@ -106,7 +107,7 @@ while($row = mysqli_fetch_assoc($result))
 <?php echo date('j M Y',strtotime($row['date'])); ?>
 </td>
 <td>
-<?php echo $row['mode']; ?>
+<?php echo invoiceFormatPaymentModes($row['mode']); ?>
 </td>
 <td>
 <?php
@@ -130,14 +131,18 @@ while($row = mysqli_fetch_assoc($result))
   }
   $grandTotal = $total - $row['discount'];
   echo $grandTotal;
-  if($row['mode'] == "CASH") {
-    $cash += $grandTotal;
-  } else if($row['mode'] == "CARD") {
-    $card += $grandTotal;
-  } else if($row['mode'] == "PAYTM") {
-    $paytm += $grandTotal;
-  } else if($row['mode'] == "UPI") {
-    $upi += $grandTotal;
+  // Attribute the grand total to its payment mode(s). Split invoices
+  // (e.g. CASH:300+UPI:200) contribute to each mode separately.
+  foreach (invoiceParsePaymentModes($row['mode'], $grandTotal) as $payMode => $payAmount) {
+    if($payMode == "CASH") {
+      $cash += $payAmount;
+    } else if($payMode == "CARD") {
+      $card += $payAmount;
+    } else if($payMode == "PAYTM") {
+      $paytm += $payAmount;
+    } else if($payMode == "UPI") {
+      $upi += $payAmount;
+    }
   }
   ?>
 </td>

--- a/pdf-functions-invoice.php
+++ b/pdf-functions-invoice.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once('invoice-payment-modes.php');
+
 class PDF extends FPDF
 {
 
@@ -128,7 +130,7 @@ class PDF extends FPDF
 		$this->Cell(70,5,"To Pay: Rs. ".$stringGrandTotal."  only",'','','L');
 		$this->Ln();
 		$this->SetFont('Arial','',12);
-		$this->Cell(70,5,"Mode of payment: ".$mode,'','','L');
+		$this->Cell(70,5,"Mode of payment: ".invoiceFormatPaymentModes($mode),'','','L');
 		$this->Ln();
 	}
 


### PR DESCRIPTION
## What & why

Lets a patient settle a single invoice using **more than one payment mode** (e.g. part cash, part UPI), which wasn't possible before — the `invoice.mode` column held a single value.

## Approach

To avoid a schema migration on the per-doctor databases, a split is **encoded inside the existing `mode` column**:

- Single mode (legacy/default): `CASH`
- Split: `CASH:300+UPI:200`

A value is treated as a split only when it contains a `:`, so **all existing single-mode rows keep working untouched**.

## Changes

- **`invoice-payment-modes.php`** (new): small helpers to parse / format / build the mode value.
- **`create-invoice.php`**: optional "Split across modes" checkbox revealing a per-mode amount box, with a live split total that warns when it doesn't match the final amount. When unused, behaviour is identical to before. Server builds the encoded mode string from the per-mode amounts (falls back to the single dropdown when no split amounts are entered). `mode` is now escaped at insert time.
- **`invoice-results.php`**: the Mode column is formatted for display, and each split amount is attributed to its own mode in the CASH/CARD/PAYTM/UPI day totals.
- **`pdf-functions-invoice.php`**: the invoice PDF renders the split modes (e.g. `Mode of payment: CASH: 300, UPI: 200`).

## Notes / testing

- Helper logic verified locally: single-mode, split parse/format, and build (multi → composite, single → legacy string, empty → blank) all behave as expected.
- `php -l` clean on all four files.
- No DB schema change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0146YqvXtyox1ZacQMHSH7LE)_