### PR TITLE
Add delete option for PDF documents attached to a visit

### DIFF
--- a/edit-sched.php
+++ b/edit-sched.php
@@ -1229,7 +1229,8 @@ document.getElementById('files').addEventListener('change', handleFileSelect, fa
             $dialogId = "dialog".$prescriptionId;
             $openerId = "opener".$prescriptionId;
 			if(strpos($prescriptionUrl, '.pdf') != false) {
-				$s = "<a href={$prescriptionUrl}>Document {$i}</a>";
+				$s = "<div style='margin:5px 0;'><a href={$prescriptionUrl} target='_blank'>Document {$i}</a> ";
+				$s .= "<button type='button' onclick=\"deletePrescription({$prescriptionId})\">Delete</button></div>";
 				echo $s;
 			} else {
 			


### PR DESCRIPTION
## Summary

PDF documents attached to a visit (in the visit row on `edit-sched.php`) were rendered as plain links with no way to remove them. Prescription **images** already had a Delete button, but **PDF documents** did not. This PR adds a Delete button next to each PDF document link.

## Changes

- `edit-sched.php`: For prescription rows whose URL is a `.pdf`, render a **Delete** button next to the "Document N" link. The button reuses the existing `deletePrescription()` JS handler and the `delete-prescription-ajax.php` endpoint that already power image deletion — no new endpoint or schema change required.
- The PDF link now also opens in a new tab (`target="_blank"`).

## Behavior

- Clicking **Delete** prompts a confirmation, then deletes the prescription record via `delete-prescription-ajax.php?id=<prescriptionId>`, identical to how images are deleted today.

## Testing

- `php -l edit-sched.php` passes with no syntax errors.
- Logic mirrors the existing image delete flow, which is already in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017BaZGQ1fjTW7WhMmPhDoSq)_